### PR TITLE
Update to fedora 34

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,2 @@
-FROM fedora:33 
+FROM fedora:34 
 RUN sudo dnf -y install cmake make gcc-c++ valgrind


### PR DESCRIPTION
CS3203 has changed the testing platform to fedora 34 for linux. Should probably update it to match the platform used.